### PR TITLE
Parallelize component install

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -336,11 +336,12 @@ tasks:
   install-components:
     desc: "All add-ons"
     silent: true
+    deps:
+      - install-flux
+      - install-cert-manager
+      - install-kyverno
+      - install-envoy-gateway-operator
     cmds:
-      - task: install-flux
-      - task: install-cert-manager
-      - task: install-kyverno
-      - task: install-envoy-gateway-operator
       - echo "✅ All cluster components installed successfully"
 
   install-cert-manager:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -303,6 +303,9 @@ tasks:
             exit 1
           fi
         fi
+      # Always install flux to the cluster so additional components can be
+      # installed using it.
+      - task: install-flux
 
   delete-kind:
     desc: "Delete KIND cluster"
@@ -337,7 +340,6 @@ tasks:
     desc: "All add-ons"
     silent: true
     deps:
-      - install-flux
       - install-cert-manager
       - install-kyverno
       - install-envoy-gateway-operator


### PR DESCRIPTION
This PR adjusts the component installation to execute deployments in parallel to speed up the cluster creation process. Flux is now installed automatically when the cluster is created since it's required by all of the components for installation. 