### PR TITLE
feat: install prom crds

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The modular layout keeps the bootstrap lean while letting teams layer in extra i
 
 ### Optional Components
 
-`task install-observability` - Deploy complete telemetry stack (Victoria Metrics, Loki, Tempo, Grafana with Promtail)
+`task install-observability` - Deploy complete telemetry stack (Victoria Metrics, Loki, Tempo, Grafana with Promtail, and Prometheus CRDs)
 
 Run `task help` to see all available targets and their descriptions.
 
@@ -146,6 +146,7 @@ task install-observability        # Add telemetry stack
 - **Loki** - Log aggregation with container log collection via Promtail
 - **Tempo** - Distributed tracing storage
 - **Grafana** - Unified dashboard (accessible at http://localhost:30000, admin/datum123)
+- **Prometheus CRDs** - Custom resources for advanced metrics scraping and alerting (servicemonitors, podmonitors, etc.)
 
 The observability stack is designed for development and testing environments with appropriate resource limits and simplified configurations.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -429,6 +429,9 @@ tasks:
           echo "$crd"
           kubectl wait --for=condition=Established "crd/${crd}" --timeout=120s || true
         done
+      - echo "⏳ Waiting for vmagent & vmsingle to be Ready (best-effort)…"
+      - kubectl wait --for=condition=Available deploy -l app.kubernetes.io/name=vmagent -n telemetry-system --timeout=120s || true
+      - kubectl wait --for=condition=Available deploy -l app.kubernetes.io/name=vmsingle -n telemetry-system --timeout=120s || true
       - echo "➡️  Applying Grafana Instance (after Operator CRDs are ready) …"
       - kubectl apply -f {{.REPO_DIR}}/components/observability/grafana-instance.yaml
       - echo "➡️  Applying Grafana Datasources …"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -414,6 +414,21 @@ tasks:
       - kubectl -n flux-system wait helmrelease/tempo --for=condition=Ready --timeout={{.WAIT_TIMEOUT}}
       - echo "⏳ Waiting for Promtail HelmRelease …"
       - kubectl -n flux-system wait helmrelease/promtail --for=condition=Ready --timeout={{.WAIT_TIMEOUT}}
+      - |
+        set -euo pipefail
+        echo "⏳ Waiting for Prometheus CRDs to be Established…"
+        for crd in \
+          servicemonitors.monitoring.coreos.com \
+          podmonitors.monitoring.coreos.com \
+          probes.monitoring.coreos.com \
+          prometheuses.monitoring.coreos.com \
+          prometheusrules.monitoring.coreos.com \
+          alertmanagers.monitoring.coreos.com \
+          thanosrulers.monitoring.coreos.com
+        do
+          echo "$crd"
+          kubectl wait --for=condition=Established "crd/${crd}" --timeout=120s || true
+        done
       - echo "➡️  Applying Grafana Instance (after Operator CRDs are ready) …"
       - kubectl apply -f {{.REPO_DIR}}/components/observability/grafana-instance.yaml
       - echo "➡️  Applying Grafana Datasources …"

--- a/components/observability/kustomization.yaml
+++ b/components/observability/kustomization.yaml
@@ -8,3 +8,6 @@ resources:
   - loki-hr.yaml
   - tempo-hr.yaml
   - promtail-hr.yaml
+  # Prometheus Operator CRDs
+  - https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.81.0/stripped-down-crds.yaml
+


### PR DESCRIPTION
Install prometheus operator crds so that developers can create standard prom resources. Note, victoria metrics will convert them into VM specific crds 