### PR TITLE
chore: bump kyverno due to removed bitnami image

### DIFF
--- a/components/kyverno/kustomization.yaml
+++ b/components/kyverno/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   # Kyverno release manifest (single file) – pin to a specific tag
-  - https://github.com/kyverno/kyverno/releases/download/v1.12.1/install.yaml?raw=true
+  - https://github.com/kyverno/kyverno/releases/download/v1.15.1/install.yaml?raw=true


### PR DESCRIPTION
This pull request updates the Kyverno manifest to use a newer release version. The change ensures that the deployment references the latest stable version of Kyverno.

* Upgraded Kyverno release manifest in `components/kyverno/kustomization.yaml` from version `v1.12.1` to `v1.15.1` to use the most recent features and fixes.

Reason: https://github.com/kyverno/kyverno/pull/13837