### PR TITLE
fix: update VictoriaMetrics datasource URL

### DIFF
--- a/components/observability/datasources/vm-datasource.yaml
+++ b/components/observability/datasources/vm-datasource.yaml
@@ -13,7 +13,7 @@ spec:
     name: VictoriaMetrics
     type: prometheus
     access: proxy
-    url: http://vmsingle-telemetry-system-vm-stack-victoria-metrics-k8s-stack.telemetry-system.svc.cluster.local:8428
+    url: http://vmsingle-telemetry-system-vm-victoria-metrics-k8s-stack.telemetry-system.svc.cluster.local:8428
     uid: victoria-metrics-datasource
     isDefault: true
     editable: true


### PR DESCRIPTION
This pull request updates the configuration for the VictoriaMetrics data source in the observability stack. The main change is a correction to the service URL to ensure connectivity to the appropriate VictoriaMetrics instance.

* Data source configuration:
  * Updated the `url` in `vm-datasource.yaml` to point to `vmsingle-telemetry-system-vm-victoria-metrics-k8s-stack` instead of `vmsingle-telemetry-system-vm-stack-victoria-metrics-k8s-stack` for the VictoriaMetrics service.