### PR TITLE
fix: accept kind versions >= minimum rather than exact match

### DIFF
--- a/hack/ensure-tools.sh
+++ b/hack/ensure-tools.sh
@@ -24,8 +24,9 @@ install_kind() {
     current="$(kind --version 2>/dev/null | awk '{print $3}')"
   fi
 
-  if [ "$current" = "$wanted" ]; then
-    echo "✅ kind $current already installed"
+  # Accept any version >= wanted (compare semver numerically)
+  if [ -n "$current" ] && printf '%s\n%s\n' "$wanted" "$current" | sort -V -C 2>/dev/null; then
+    echo "✅ kind $current already installed (>= $wanted)"
     return 0
   fi
 


### PR DESCRIPTION
## Summary

I have kind 0.31 in my PATH but ensure-tools.sh really wants to use 0.30 and needing sudo during the process. If a newer version is available, it makes sense to just use that.

- Changed `install_kind` in `hack/ensure-tools.sh` to accept any installed kind version >= the pinned minimum, rather than requiring an exact match
- Uses `sort -V -C` for semver-aware comparison

## Test plan

- [X] Run `ensure-tools.sh kind` with kind 0.31 installed — should skip install and print "already installed"
- [ ] Run with kind 0.29 installed — should trigger install