### PR TITLE
Fix missing time unit on kind-bootstrap timeout default

### DIFF
--- a/.github/actions/kind-bootstrap/action.yaml
+++ b/.github/actions/kind-bootstrap/action.yaml
@@ -8,9 +8,9 @@ inputs:
     required: false
     default: test-infra
   wait_timeout:
-    description: "Seconds to wait for add-ons to become Ready"
+    description: "Time to wait for add-ons to become Ready (e.g. 300s, 5m)"
     required: false
-    default: "300"
+    default: "300s"
   images:
     description: "Space-separated list of Docker images to load into kind (optional)"
     required: false


### PR DESCRIPTION
## Summary

While setting up an e2e testing environment for [unikraft-provider](https://github.com/datum-cloud/unikraft-provider), the `kind-bootstrap` action failed because `kubectl wait --timeout 300` is missing the `s` duration suffix. Newer kubectl versions require it.

Fixes the `wait_timeout` input default from `300` to `300s`.