### PR TITLE
fix: respect KUBECONFIG env var in external repo fallback

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,8 +11,10 @@ vars:
     sh: |
       if [ -f "cluster/kind-config.yaml" ] && [ -f "components/flux/kustomization.yaml" ]; then
         echo "./kubeconfig"  # In test-infra repo
+      elif [ -n "$KUBECONFIG" ] && [ -f "$KUBECONFIG" ]; then
+        echo "$KUBECONFIG"  # External repo: use KUBECONFIG env var if set and file exists
       else
-        echo ".test-infra/kubeconfig"  # External repo
+        echo ".test-infra/kubeconfig"  # External repo: default fallback
       fi
   # Detect if we're running in the test-infra repo or externally
   REPO_DIR:


### PR DESCRIPTION
## Summary

- Fixes the `KUBECONFIG_FILE` variable in `Taskfile.yml` to check the `KUBECONFIG` environment variable before falling back to the hardcoded `.test-infra/kubeconfig` path when running from an external repo.
- This resolves compatibility with the `kind-bootstrap` GitHub Action, which writes the kubeconfig to its own location and sets `KUBECONFIG` accordingly.

Discovered in datum-cloud/unikraft-provider#2.

## Test plan

- [ ] Verify that `task` commands work in an external repo when `KUBECONFIG` env var is set by the `kind-bootstrap` action
- [ ] Verify that the default `.test-infra/kubeconfig` fallback still works when `KUBECONFIG` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)