### PR TITLE
chore: bump Envoy Gateway v1.4.3 -> v1.7.3

### DIFF
--- a/components/envoy-gateway-operator/oci-repository.yaml
+++ b/components/envoy-gateway-operator/oci-repository.yaml
@@ -7,4 +7,4 @@ spec:
   interval: 12h
   url: oci://docker.io/envoyproxy/gateway-helm
   ref:
-    tag: v1.4.3
+    tag: v1.7.3


### PR DESCRIPTION
## Summary

Bumps the Envoy Gateway control plane from **v1.4.3 → v1.7.3** by updating the OCIRepository tag in `components/envoy-gateway-operator/oci-repository.yaml`. The HelmRelease pulls chart + appVersion via `chartRef`, so the OCI tag is the only pin that needs to change.

## Why

network-services-operator (NSO) programs downstream Gateways and `EnvoyPatchPolicy` resources whose xDS resource names (e.g. `http-80`, `<ns>/<gw>/<listener>` route configs, `httproute/<ns>/<name>/rule/<idx>` clusters) must match the Envoy Gateway version running in prod. We are standing up a controlled xDS-build-cost experiment on top of test-infra and need the control plane to be v1.7.3 to keep fidelity with production.

## Validation

```
kustomize build components/envoy-gateway-operator
kustomize build components/envoy-gateway-operator/gateway-resources
```

Both render cleanly. The `gateway-resources` EnvoyProxy/GatewayClass use only fields stable across 1.4 → 1.7 (`mergeGateways`, `provider.kubernetes.envoyService/envoyDeployment`, `telemetry.metrics.prometheus`); no CRD field removals affect these manifests. Full apply-time validation against live v1.7.3 CRDs is exercised by the consuming experiment (`network-services-operator/experiments/xds-scaling`).

## Risk

Low. Single tag change; flux reconciles the HelmRelease and rolls the `envoy-gateway` deployment. Rollback is reverting the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)