### PR TITLE
chore(envoy-gateway): bump to v1.8.2 (latest stable)

### DIFF
--- a/components/envoy-gateway-operator/oci-repository.yaml
+++ b/components/envoy-gateway-operator/oci-repository.yaml
@@ -7,4 +7,4 @@ spec:
   interval: 12h
   url: oci://docker.io/envoyproxy/gateway-helm
   ref:
-    tag: v1.4.3
+    tag: v1.8.2


### PR DESCRIPTION
Bumps the shared Envoy Gateway operator to **v1.8.2**, the latest stable upstream release (was v1.4.3).

Keeps the operator current with upstream — picking up the accumulated fixes, Gateway API CRD updates, and the newer Envoy Proxy data plane (v1.38.x) that ship with the 1.8.x line.

Scope: a single tag bump in `components/envoy-gateway-operator/oci-repository.yaml`. A fresh `cluster-up` installs the matching Gateway API + EnvoyProxy CRDs from the chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)