### PR TITLE
fix(observability): make a cold install-observability succeed from zero

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -444,8 +444,22 @@ tasks:
       - kubectl wait --for=condition=Available deploy -l app.kubernetes.io/name=vmsingle -n telemetry-system --timeout=120s || true
       - echo "⏳ Waiting for OpenTelemetryCollector CRD to be Established …"
       - kubectl wait --for=condition=Established crd/opentelemetrycollectors.opentelemetry.io --timeout={{.WAIT_TIMEOUT}}
-      - echo "➡️  Applying OpenTelemetryCollector CR …"
-      - kubectl apply -f {{.REPO_DIR}}/components/observability/otel-collector/opentelemetry-collector.yaml
+      - echo "➡️  Applying OpenTelemetryCollector CR (waiting for the operator webhook) …"
+      - |
+        set -euo pipefail
+        # HR-Ready + CRD-Established do NOT guarantee the operator's admission
+        # webhook is serving with an injected caBundle — both happen
+        # asynchronously after the Helm install. Wait for the operator
+        # Deployment, then retry the apply so a cold-start caBundle-injection
+        # lag can't fail the install with an x509 / "no endpoints" webhook error.
+        kubectl -n telemetry-system wait --for=condition=Available \
+          deploy -l app.kubernetes.io/name=opentelemetry-operator --timeout={{.WAIT_TIMEOUT}}
+        for i in $(seq 1 30); do
+          kubectl apply -f {{.REPO_DIR}}/components/observability/otel-collector/opentelemetry-collector.yaml && break
+          [ "$i" = 30 ] && { echo "OpenTelemetryCollector apply failed after retries" >&2; exit 1; }
+          echo "  operator webhook not ready yet, retrying ($i)…" >&2
+          sleep 5
+        done
       - echo "⏳ Waiting for OTel Collector DaemonSet …"
       - kubectl -n telemetry-system rollout status daemonset/otel-collector-collector --timeout={{.WAIT_TIMEOUT}}
       - echo "➡️  Applying Grafana Instance (after Operator CRDs are ready) …"

--- a/components/cert-manager/cert-manager-hr.yaml
+++ b/components/cert-manager/cert-manager-hr.yaml
@@ -47,11 +47,16 @@ spec:
           memory: 64Mi
 
     # CA Injector configuration
+    # cainjector caches every CRD, APIService, and webhook config in the
+    # cluster to inject CA bundles, so its memory scales with cluster object
+    # count. 64Mi is enough for a bare cluster but OOMKills (exit 137) once the
+    # optional observability stack adds its CRDs/webhooks — which then blocks
+    # webhook caBundle injection (e.g. the OTel operator's), so give it room.
     cainjector:
       resources:
         requests:
           cpu: 5m
-          memory: 16Mi
+          memory: 32Mi
         limits:
-          cpu: 50m
-          memory: 64Mi
+          cpu: 100m
+          memory: 256Mi

--- a/components/observability/kustomization.yaml
+++ b/components/observability/kustomization.yaml
@@ -9,7 +9,11 @@ resources:
   - tempo-hr.yaml
   - otel-collector/helm-repository.yaml
   - otel-collector/helm-release-operator.yaml
-  - otel-collector/opentelemetry-collector.yaml
+  # NOTE: otel-collector/opentelemetry-collector.yaml is intentionally NOT
+  # listed here. It is an OpenTelemetryCollector CR whose CRD and validating
+  # webhook are installed by the operator HelmRelease above. Applying it in
+  # this bundle races the operator, so the install-observability task applies
+  # it in a dedicated step after the CRD is Established (and the webhook ready).
   # Prometheus Operator CRDs
   - https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.81.0/stripped-down-crds.yaml
 

--- a/components/observability/loki-hr.yaml
+++ b/components/observability/loki-hr.yaml
@@ -59,6 +59,15 @@ spec:
           cpu: 200m
           memory: 512Mi
 
+    # The chart enables memcached chunk/results caches by default, each
+    # requesting ~8-9Gi of memory — they stay Pending (Insufficient memory) on
+    # a single-node kind cluster, leaving the Loki HelmRelease permanently
+    # not-Ready. They add nothing for a SingleBinary + filesystem dev setup.
+    chunksCache:
+      enabled: false
+    resultsCache:
+      enabled: false
+
     # Disable all other components
     backend:
       replicas: 0


### PR DESCRIPTION
## Problem

`task install-observability` on a fresh cluster fails partway through and needs manual recovery to finish. Independent causes, each of which aborts the install on its own.

## Fixes

**1. OTel Collector CR install was racy — now ordered and retried.** The `OpenTelemetryCollector` CR was listed in `components/observability/kustomization.yaml`, so the task's first `kustomize build | kubectl apply` tried to create it before its CRD/webhook existed (`no matches for kind`). The task *does* also apply it in a dedicated step — but that step only waited for the operator HelmRelease Ready + CRD Established, and **neither guarantees the operator's admission webhook is serving with an injected caBundle** (both are async after the Helm install), so it still failed with an `x509` / `no endpoints` webhook error on a cold cluster. Fix: drop the CR from the bundle (so it is installed exactly once, in order), and in the dedicated step wait for the operator Deployment to be Available and **retry the apply** until the webhook is ready.

**2. cert-manager cainjector OOMKilled.** cainjector caches every CRD/APIService/webhook to inject CA bundles, so its memory scales with cluster object count. At 64Mi it OOMKills (exit 137) once the stack's CRDs/webhooks land — and until it's healthy it never injects the OTel operator's webhook caBundle (cause #1's `x509`). Raised to 256Mi.

**3. Loki HelmRelease never went Ready.** The Loki chart enables memcached chunk/results caches by default, each requesting ~8-9Gi, which stay `Pending` (Insufficient memory) on a single-node cluster and hold the Loki HelmRelease not-Ready — so `wait helmrelease/loki` fails even though everything else is up. Disabled both caches (unneeded for the SingleBinary + filesystem dev setup).

## How the collector is installed now

Still installed **as part of `install-observability`** — just once, in order. It was being applied twice: prematurely in the bulk `kustomize build | kubectl apply` at the top of the task (before its CRD/webhook existed → the cold-start failure), and again in a dedicated step. This drops the premature bundle copy and keeps the dedicated step, which now (a) waits for the CRD Established, (b) waits for the operator Deployment Available, and (c) retries `kubectl apply` of the CR until the admission webhook accepts it — then waits on the collector DaemonSet rollout. `components/observability` has no other (e.g. Flux/GitOps) consumer, so this is the single install path.

## Result

`task install-observability` completes clean from a fresh cluster with no manual intervention.

## Verification

Applied all of this on a live cold install: cainjector stable at 256Mi, OTel Collector DaemonSet Ready, and end-to-end telemetry confirmed — assistant metrics scraped into Victoria Metrics (`up{job="assistant"}=1`) and traces landing in Tempo.
